### PR TITLE
fix: use named function

### DIFF
--- a/src/request-context.middleware.ts
+++ b/src/request-context.middleware.ts
@@ -23,7 +23,7 @@ export class RequestContextMiddleware<T extends RequestContext> implements NestM
 export function requestContextMiddleware<T extends RequestContext>(
   contextClass: (new () => T),
 ): (req: Request, res: Response, next: NextFunction) => void {
-  return (req: Request, res: Response, next: NextFunction): void => {
+  return function RequestContextMiddleware(req: Request, res: Response, next: NextFunction): void {
     middleware(contextClass, req, res, next);
   }
 }


### PR DESCRIPTION
Use named function to not have `anymous()` showing up in APM.